### PR TITLE
Setup buf CI

### DIFF
--- a/.github/workflows/buf.yml
+++ b/.github/workflows/buf.yml
@@ -1,0 +1,32 @@
+name: Buf
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - buf.yaml
+      - proto/**
+      - .github/workflows/buf.yml
+  pull_request:
+    branches:
+      - main
+    paths:
+      - buf.yaml
+      - proto/**
+      - .github/workflows/buf.yml
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4.2.2
+
+      - uses: bufbuild/buf-action@v1.0.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/proto/aegs/clover/v1/models.proto
+++ b/proto/aegs/clover/v1/models.proto
@@ -63,6 +63,7 @@ message Pass {
   bool is_available = 4;
 }
 
+// パスの AOS/LOS 時刻と最大仰角といった詳細情報。
 message PassDetails {
   // AOS (Acquisition of Signal) 時刻
   google.protobuf.Timestamp aos = 1;
@@ -99,6 +100,7 @@ message Contact {
   // コンタクト時刻の前後にパスが見つからなかった場合は値が設定されない
   PassDetails pass = 9;
 
+  // コンタクトの状態。
   enum Status {
     // ステータスの値が設定されていない場合の値。
     // この値が設定された場合は異常な状態であるため、アークエッジ・スペースの担当者に連絡すること


### PR DESCRIPTION
Buf https://buf.build/ による proto ファイルの format, lint, breaking changes の検知のための CI をセットアップします。

cf. https://buf.build/docs/ci-cd/github-actions/