### PR TITLE
Add buf.yaml

### DIFF
--- a/buf.yaml
+++ b/buf.yaml
@@ -1,0 +1,14 @@
+# For details on buf.yaml configuration, visit https://buf.build/docs/configuration/v2/buf-yaml
+version: v2
+modules:
+  - path: proto
+lint:
+  use:
+    - STANDARD
+    - COMMENTS
+  ignore_only:
+    COMMENT_MESSAGE:
+      - proto/aegs/clover/v1/clover_service.proto
+breaking:
+  use:
+    - FILE


### PR DESCRIPTION
https://github.com/arkedge/clover-api/pull/2 で追加した CI で Breaking のチェックが fail してしまうので、先立って buf.yaml のみを追加します。