### PR TITLE
Use paths-ignore in docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,20 +3,14 @@ name: Documentation
 on:
   push:
     branches: ["main"]
-    paths:
-      - book.toml
-      - custom.css
-      - docs/**
-      - proto/**
-      - .github/workflows/docs.yml
+    paths-ignore:
+      - client-ui/**
+      - .github/workflows/client-ui.yml
   pull_request:
     branches: ["main"]
-    paths:
-      - book.toml
-      - custom.css
-      - docs/**
-      - proto/**
-      - .github/workflows/docs.yml
+    paths-ignore:
+      - client-ui/**
+      - .github/workflows/client-ui.yml
 
 jobs:
   build:


### PR DESCRIPTION
Ruleset で build job が pass することを条件にしているので、必ず build job が実行されるよう docs workflow の起動条件を修正します。