### PR TITLE
Set prHourlyLimit in Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -25,5 +25,6 @@
       "matchUpdateTypes": ["minor", "patch"],
       "automerge": true
     }
-  ]
+  ],
+  "prHourlyLimit": 0
 }


### PR DESCRIPTION
`schedule:earlyMondays` では、週に1〜数回しか Renovate のジョブが動かず、更新対象のパッケージに対して PR 作成が追いつかないので、デフォルトで 2 となっている `prHourlyLimit` の制限をなくします。

https://docs.renovatebot.com/configuration-options/#prhourlylimit