### PR TITLE
clover-ui: Enable to download contact blobs

### DIFF
--- a/client-ui/app/.server/CloverClient.ts
+++ b/client-ui/app/.server/CloverClient.ts
@@ -78,6 +78,11 @@ export class CloverClient {
     return response.contacts.map((contact) => toJson(ContactSchema, contact));
   }
 
+  async listPastContacts(satelliteId: bigint) {
+    const response = await this.client.listPastContacts({ satelliteId });
+    return response.contacts.map((contact) => toJson(ContactSchema, contact));
+  }
+
   async getContact(contactId: bigint) {
     try {
       const response = await this.client.getContact({ contactId });

--- a/client-ui/app/.server/CloverClient.ts
+++ b/client-ui/app/.server/CloverClient.ts
@@ -3,6 +3,7 @@ import { timestampFromDate } from "@bufbuild/protobuf/wkt";
 import { Client, Code, ConnectError, createClient } from "@connectrpc/connect";
 import { CloverService } from "~/gen/aegs/clover/v1/clover_service_pb";
 import {
+  BlobFileSchema,
   ContactSchema,
   GroundStationSchema,
   PassSchema,
@@ -122,5 +123,20 @@ export class CloverClient {
       groundStationIds,
     });
     return response.passes.map((pass) => toJson(PassSchema, pass));
+  }
+
+  async listContactBlobFiles(contactId: bigint) {
+    try {
+      const response = await this.client.listContactBlobFiles({ contactId });
+      return response.blobFiles.map((blobFile) =>
+        toJson(BlobFileSchema, blobFile),
+      );
+    } catch (err) {
+      if (err instanceof ConnectError && err.code === Code.FailedPrecondition) {
+        return null;
+      } else {
+        throw err;
+      }
+    }
   }
 }

--- a/client-ui/app/components/ContactTable.tsx
+++ b/client-ui/app/components/ContactTable.tsx
@@ -1,0 +1,49 @@
+import { HTMLTable } from "@blueprintjs/core";
+import { Link } from "@remix-run/react";
+import { ContactJson, GroundStationJson } from "~/gen/aegs/clover/v1/models_pb";
+import { ContactStatusTag } from "./ContactStatusTag";
+
+interface Props {
+  contacts: ContactJson[];
+  groundStations: GroundStationJson[];
+}
+
+export const ContactTable = ({ contacts, groundStations }: Props) => {
+  return (
+    <HTMLTable striped={true} interactive={true} className="w-full">
+      <thead>
+        <tr>
+          <th>ID</th>
+          <th>Ground Station</th>
+          <th>Start Time</th>
+          <th>End Time</th>
+          <th>Status</th>
+        </tr>
+      </thead>
+      <tbody>
+        {contacts.map((contact) => (
+          <tr key={contact.id} className="relative">
+            <td>
+              <Link
+                to={`/contacts/${contact.id}`}
+                className="absolute inset-0"
+              />
+              {contact.id}
+            </td>
+            <td>
+              {
+                groundStations.find((gs) => gs.id === contact.groundStationId)
+                  ?.name
+              }
+            </td>
+            <td>{contact.startTime}</td>
+            <td>{contact.endTime}</td>
+            <td>
+              <ContactStatusTag status={contact.status!} />
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </HTMLTable>
+  );
+};

--- a/client-ui/app/gen/aegs/clover/v1/clover_service_pb.ts
+++ b/client-ui/app/gen/aegs/clover/v1/clover_service_pb.ts
@@ -4,7 +4,7 @@
 
 import type { GenFile, GenMessage, GenService } from "@bufbuild/protobuf/codegenv1";
 import { fileDesc, messageDesc, serviceDesc } from "@bufbuild/protobuf/codegenv1";
-import type { Contact, ContactJson, GroundStation, GroundStationJson, Pass, PassJson, Satellite, SatelliteJson, TLE, TLEJson, TLERecord, TLERecordJson } from "./models_pb";
+import type { BlobFile, BlobFileJson, Contact, ContactJson, GroundStation, GroundStationJson, Pass, PassJson, Satellite, SatelliteJson, TLE, TLEJson, TLERecord, TLERecordJson } from "./models_pb";
 import { file_aegs_clover_v1_models } from "./models_pb";
 import type { Timestamp, TimestampJson } from "@bufbuild/protobuf/wkt";
 import { file_google_protobuf_timestamp } from "@bufbuild/protobuf/wkt";
@@ -14,7 +14,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file aegs/clover/v1/clover_service.proto.
  */
 export const file_aegs_clover_v1_clover_service: GenFile = /*@__PURE__*/
-  fileDesc("CiNhZWdzL2Nsb3Zlci92MS9jbG92ZXJfc2VydmljZS5wcm90bxIOYWVncy5jbG92ZXIudjEiFwoVTGlzdFNhdGVsbGl0ZXNSZXF1ZXN0IkcKFkxpc3RTYXRlbGxpdGVzUmVzcG9uc2USLQoKc2F0ZWxsaXRlcxgBIAMoCzIZLmFlZ3MuY2xvdmVyLnYxLlNhdGVsbGl0ZSIrChNHZXRTYXRlbGxpdGVSZXF1ZXN0EhQKDHNhdGVsbGl0ZV9pZBgBIAEoAyJEChRHZXRTYXRlbGxpdGVSZXNwb25zZRIsCglzYXRlbGxpdGUYASABKAsyGS5hZWdzLmNsb3Zlci52MS5TYXRlbGxpdGUiKwoTR2V0TGF0ZXN0VExFUmVxdWVzdBIUCgxzYXRlbGxpdGVfaWQYASABKAMiRQoUR2V0TGF0ZXN0VExFUmVzcG9uc2USLQoKdGxlX3JlY29yZBgBIAEoCzIZLmFlZ3MuY2xvdmVyLnYxLlRMRVJlY29yZCJMChJSZWdpc3RlclRMRVJlcXVlc3QSFAoMc2F0ZWxsaXRlX2lkGAEgASgDEiAKA3RsZRgCIAEoCzITLmFlZ3MuY2xvdmVyLnYxLlRMRSJEChNSZWdpc3RlclRMRVJlc3BvbnNlEi0KCnRsZV9yZWNvcmQYASABKAsyGS5hZWdzLmNsb3Zlci52MS5UTEVSZWNvcmQiOgoiTGlzdEF2YWlsYWJsZUdyb3VuZFN0YXRpb25zUmVxdWVzdBIUCgxzYXRlbGxpdGVfaWQYASABKAMiXQojTGlzdEF2YWlsYWJsZUdyb3VuZFN0YXRpb25zUmVzcG9uc2USNgoPZ3JvdW5kX3N0YXRpb25zGAEgAygLMh0uYWVncy5jbG92ZXIudjEuR3JvdW5kU3RhdGlvbiI0ChdHZXRHcm91bmRTdGF0aW9uUmVxdWVzdBIZChFncm91bmRfc3RhdGlvbl9pZBgBIAEoAyJRChhHZXRHcm91bmRTdGF0aW9uUmVzcG9uc2USNQoOZ3JvdW5kX3N0YXRpb24YASABKAsyHS5hZWdzLmNsb3Zlci52MS5Hcm91bmRTdGF0aW9uIkUKEUxpc3RQYXNzZXNSZXF1ZXN0EhQKDHNhdGVsbGl0ZV9pZBgBIAEoAxIaChJncm91bmRfc3RhdGlvbl9pZHMYAiADKAMiOgoSTGlzdFBhc3Nlc1Jlc3BvbnNlEiQKBnBhc3NlcxgBIAMoCzIULmFlZ3MuY2xvdmVyLnYxLlBhc3MiMwobTGlzdFVwY29taW5nQ29udGFjdHNSZXF1ZXN0EhQKDHNhdGVsbGl0ZV9pZBgBIAEoAyJJChxMaXN0VXBjb21pbmdDb250YWN0c1Jlc3BvbnNlEikKCGNvbnRhY3RzGAEgAygLMhcuYWVncy5jbG92ZXIudjEuQ29udGFjdCInChFHZXRDb250YWN0UmVxdWVzdBISCgpjb250YWN0X2lkGAEgASgDIj4KEkdldENvbnRhY3RSZXNwb25zZRIoCgdjb250YWN0GAEgASgLMhcuYWVncy5jbG92ZXIudjEuQ29udGFjdCKZAQoUQ3JlYXRlQ29udGFjdFJlcXVlc3QSFAoMc2F0ZWxsaXRlX2lkGAEgASgDEhkKEWdyb3VuZF9zdGF0aW9uX2lkGAIgASgDEicKA2FvcxgDIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASJwoDbG9zGAQgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcCJBChVDcmVhdGVDb250YWN0UmVzcG9uc2USKAoHY29udGFjdBgBIAEoCzIXLmFlZ3MuY2xvdmVyLnYxLkNvbnRhY3QiKgoUQ2FuY2VsQ29udGFjdFJlcXVlc3QSEgoKY29udGFjdF9pZBgBIAEoAyJBChVDYW5jZWxDb250YWN0UmVzcG9uc2USKAoHY29udGFjdBgBIAEoCzIXLmFlZ3MuY2xvdmVyLnYxLkNvbnRhY3QyxwgKDUNsb3ZlclNlcnZpY2USXwoOTGlzdFNhdGVsbGl0ZXMSJS5hZWdzLmNsb3Zlci52MS5MaXN0U2F0ZWxsaXRlc1JlcXVlc3QaJi5hZWdzLmNsb3Zlci52MS5MaXN0U2F0ZWxsaXRlc1Jlc3BvbnNlElkKDEdldFNhdGVsbGl0ZRIjLmFlZ3MuY2xvdmVyLnYxLkdldFNhdGVsbGl0ZVJlcXVlc3QaJC5hZWdzLmNsb3Zlci52MS5HZXRTYXRlbGxpdGVSZXNwb25zZRJZCgxHZXRMYXRlc3RUTEUSIy5hZWdzLmNsb3Zlci52MS5HZXRMYXRlc3RUTEVSZXF1ZXN0GiQuYWVncy5jbG92ZXIudjEuR2V0TGF0ZXN0VExFUmVzcG9uc2USVgoLUmVnaXN0ZXJUTEUSIi5hZWdzLmNsb3Zlci52MS5SZWdpc3RlclRMRVJlcXVlc3QaIy5hZWdzLmNsb3Zlci52MS5SZWdpc3RlclRMRVJlc3BvbnNlEoYBChtMaXN0QXZhaWxhYmxlR3JvdW5kU3RhdGlvbnMSMi5hZWdzLmNsb3Zlci52MS5MaXN0QXZhaWxhYmxlR3JvdW5kU3RhdGlvbnNSZXF1ZXN0GjMuYWVncy5jbG92ZXIudjEuTGlzdEF2YWlsYWJsZUdyb3VuZFN0YXRpb25zUmVzcG9uc2USZQoQR2V0R3JvdW5kU3RhdGlvbhInLmFlZ3MuY2xvdmVyLnYxLkdldEdyb3VuZFN0YXRpb25SZXF1ZXN0GiguYWVncy5jbG92ZXIudjEuR2V0R3JvdW5kU3RhdGlvblJlc3BvbnNlElMKCkxpc3RQYXNzZXMSIS5hZWdzLmNsb3Zlci52MS5MaXN0UGFzc2VzUmVxdWVzdBoiLmFlZ3MuY2xvdmVyLnYxLkxpc3RQYXNzZXNSZXNwb25zZRJxChRMaXN0VXBjb21pbmdDb250YWN0cxIrLmFlZ3MuY2xvdmVyLnYxLkxpc3RVcGNvbWluZ0NvbnRhY3RzUmVxdWVzdBosLmFlZ3MuY2xvdmVyLnYxLkxpc3RVcGNvbWluZ0NvbnRhY3RzUmVzcG9uc2USUwoKR2V0Q29udGFjdBIhLmFlZ3MuY2xvdmVyLnYxLkdldENvbnRhY3RSZXF1ZXN0GiIuYWVncy5jbG92ZXIudjEuR2V0Q29udGFjdFJlc3BvbnNlElwKDUNyZWF0ZUNvbnRhY3QSJC5hZWdzLmNsb3Zlci52MS5DcmVhdGVDb250YWN0UmVxdWVzdBolLmFlZ3MuY2xvdmVyLnYxLkNyZWF0ZUNvbnRhY3RSZXNwb25zZRJcCg1DYW5jZWxDb250YWN0EiQuYWVncy5jbG92ZXIudjEuQ2FuY2VsQ29udGFjdFJlcXVlc3QaJS5hZWdzLmNsb3Zlci52MS5DYW5jZWxDb250YWN0UmVzcG9uc2ViBnByb3RvMw", [file_aegs_clover_v1_models, file_google_protobuf_timestamp]);
+  fileDesc("CiNhZWdzL2Nsb3Zlci92MS9jbG92ZXJfc2VydmljZS5wcm90bxIOYWVncy5jbG92ZXIudjEiFwoVTGlzdFNhdGVsbGl0ZXNSZXF1ZXN0IkcKFkxpc3RTYXRlbGxpdGVzUmVzcG9uc2USLQoKc2F0ZWxsaXRlcxgBIAMoCzIZLmFlZ3MuY2xvdmVyLnYxLlNhdGVsbGl0ZSIrChNHZXRTYXRlbGxpdGVSZXF1ZXN0EhQKDHNhdGVsbGl0ZV9pZBgBIAEoAyJEChRHZXRTYXRlbGxpdGVSZXNwb25zZRIsCglzYXRlbGxpdGUYASABKAsyGS5hZWdzLmNsb3Zlci52MS5TYXRlbGxpdGUiKwoTR2V0TGF0ZXN0VExFUmVxdWVzdBIUCgxzYXRlbGxpdGVfaWQYASABKAMiRQoUR2V0TGF0ZXN0VExFUmVzcG9uc2USLQoKdGxlX3JlY29yZBgBIAEoCzIZLmFlZ3MuY2xvdmVyLnYxLlRMRVJlY29yZCJMChJSZWdpc3RlclRMRVJlcXVlc3QSFAoMc2F0ZWxsaXRlX2lkGAEgASgDEiAKA3RsZRgCIAEoCzITLmFlZ3MuY2xvdmVyLnYxLlRMRSJEChNSZWdpc3RlclRMRVJlc3BvbnNlEi0KCnRsZV9yZWNvcmQYASABKAsyGS5hZWdzLmNsb3Zlci52MS5UTEVSZWNvcmQiOgoiTGlzdEF2YWlsYWJsZUdyb3VuZFN0YXRpb25zUmVxdWVzdBIUCgxzYXRlbGxpdGVfaWQYASABKAMiXQojTGlzdEF2YWlsYWJsZUdyb3VuZFN0YXRpb25zUmVzcG9uc2USNgoPZ3JvdW5kX3N0YXRpb25zGAEgAygLMh0uYWVncy5jbG92ZXIudjEuR3JvdW5kU3RhdGlvbiI0ChdHZXRHcm91bmRTdGF0aW9uUmVxdWVzdBIZChFncm91bmRfc3RhdGlvbl9pZBgBIAEoAyJRChhHZXRHcm91bmRTdGF0aW9uUmVzcG9uc2USNQoOZ3JvdW5kX3N0YXRpb24YASABKAsyHS5hZWdzLmNsb3Zlci52MS5Hcm91bmRTdGF0aW9uIkUKEUxpc3RQYXNzZXNSZXF1ZXN0EhQKDHNhdGVsbGl0ZV9pZBgBIAEoAxIaChJncm91bmRfc3RhdGlvbl9pZHMYAiADKAMiOgoSTGlzdFBhc3Nlc1Jlc3BvbnNlEiQKBnBhc3NlcxgBIAMoCzIULmFlZ3MuY2xvdmVyLnYxLlBhc3MiMwobTGlzdFVwY29taW5nQ29udGFjdHNSZXF1ZXN0EhQKDHNhdGVsbGl0ZV9pZBgBIAEoAyJJChxMaXN0VXBjb21pbmdDb250YWN0c1Jlc3BvbnNlEikKCGNvbnRhY3RzGAEgAygLMhcuYWVncy5jbG92ZXIudjEuQ29udGFjdCIvChdMaXN0UGFzdENvbnRhY3RzUmVxdWVzdBIUCgxzYXRlbGxpdGVfaWQYASABKAMiRQoYTGlzdFBhc3RDb250YWN0c1Jlc3BvbnNlEikKCGNvbnRhY3RzGAEgAygLMhcuYWVncy5jbG92ZXIudjEuQ29udGFjdCInChFHZXRDb250YWN0UmVxdWVzdBISCgpjb250YWN0X2lkGAEgASgDIj4KEkdldENvbnRhY3RSZXNwb25zZRIoCgdjb250YWN0GAEgASgLMhcuYWVncy5jbG92ZXIudjEuQ29udGFjdCKZAQoUQ3JlYXRlQ29udGFjdFJlcXVlc3QSFAoMc2F0ZWxsaXRlX2lkGAEgASgDEhkKEWdyb3VuZF9zdGF0aW9uX2lkGAIgASgDEicKA2FvcxgDIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASJwoDbG9zGAQgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcCJBChVDcmVhdGVDb250YWN0UmVzcG9uc2USKAoHY29udGFjdBgBIAEoCzIXLmFlZ3MuY2xvdmVyLnYxLkNvbnRhY3QiKgoUQ2FuY2VsQ29udGFjdFJlcXVlc3QSEgoKY29udGFjdF9pZBgBIAEoAyJBChVDYW5jZWxDb250YWN0UmVzcG9uc2USKAoHY29udGFjdBgBIAEoCzIXLmFlZ3MuY2xvdmVyLnYxLkNvbnRhY3QiMQobTGlzdENvbnRhY3RCbG9iRmlsZXNSZXF1ZXN0EhIKCmNvbnRhY3RfaWQYASABKAMiTAocTGlzdENvbnRhY3RCbG9iRmlsZXNSZXNwb25zZRIsCgpibG9iX2ZpbGVzGAEgAygLMhguYWVncy5jbG92ZXIudjEuQmxvYkZpbGUyoQoKDUNsb3ZlclNlcnZpY2USXwoOTGlzdFNhdGVsbGl0ZXMSJS5hZWdzLmNsb3Zlci52MS5MaXN0U2F0ZWxsaXRlc1JlcXVlc3QaJi5hZWdzLmNsb3Zlci52MS5MaXN0U2F0ZWxsaXRlc1Jlc3BvbnNlElkKDEdldFNhdGVsbGl0ZRIjLmFlZ3MuY2xvdmVyLnYxLkdldFNhdGVsbGl0ZVJlcXVlc3QaJC5hZWdzLmNsb3Zlci52MS5HZXRTYXRlbGxpdGVSZXNwb25zZRJZCgxHZXRMYXRlc3RUTEUSIy5hZWdzLmNsb3Zlci52MS5HZXRMYXRlc3RUTEVSZXF1ZXN0GiQuYWVncy5jbG92ZXIudjEuR2V0TGF0ZXN0VExFUmVzcG9uc2USVgoLUmVnaXN0ZXJUTEUSIi5hZWdzLmNsb3Zlci52MS5SZWdpc3RlclRMRVJlcXVlc3QaIy5hZWdzLmNsb3Zlci52MS5SZWdpc3RlclRMRVJlc3BvbnNlEoYBChtMaXN0QXZhaWxhYmxlR3JvdW5kU3RhdGlvbnMSMi5hZWdzLmNsb3Zlci52MS5MaXN0QXZhaWxhYmxlR3JvdW5kU3RhdGlvbnNSZXF1ZXN0GjMuYWVncy5jbG92ZXIudjEuTGlzdEF2YWlsYWJsZUdyb3VuZFN0YXRpb25zUmVzcG9uc2USZQoQR2V0R3JvdW5kU3RhdGlvbhInLmFlZ3MuY2xvdmVyLnYxLkdldEdyb3VuZFN0YXRpb25SZXF1ZXN0GiguYWVncy5jbG92ZXIudjEuR2V0R3JvdW5kU3RhdGlvblJlc3BvbnNlElMKCkxpc3RQYXNzZXMSIS5hZWdzLmNsb3Zlci52MS5MaXN0UGFzc2VzUmVxdWVzdBoiLmFlZ3MuY2xvdmVyLnYxLkxpc3RQYXNzZXNSZXNwb25zZRJxChRMaXN0VXBjb21pbmdDb250YWN0cxIrLmFlZ3MuY2xvdmVyLnYxLkxpc3RVcGNvbWluZ0NvbnRhY3RzUmVxdWVzdBosLmFlZ3MuY2xvdmVyLnYxLkxpc3RVcGNvbWluZ0NvbnRhY3RzUmVzcG9uc2USZQoQTGlzdFBhc3RDb250YWN0cxInLmFlZ3MuY2xvdmVyLnYxLkxpc3RQYXN0Q29udGFjdHNSZXF1ZXN0GiguYWVncy5jbG92ZXIudjEuTGlzdFBhc3RDb250YWN0c1Jlc3BvbnNlElMKCkdldENvbnRhY3QSIS5hZWdzLmNsb3Zlci52MS5HZXRDb250YWN0UmVxdWVzdBoiLmFlZ3MuY2xvdmVyLnYxLkdldENvbnRhY3RSZXNwb25zZRJcCg1DcmVhdGVDb250YWN0EiQuYWVncy5jbG92ZXIudjEuQ3JlYXRlQ29udGFjdFJlcXVlc3QaJS5hZWdzLmNsb3Zlci52MS5DcmVhdGVDb250YWN0UmVzcG9uc2USXAoNQ2FuY2VsQ29udGFjdBIkLmFlZ3MuY2xvdmVyLnYxLkNhbmNlbENvbnRhY3RSZXF1ZXN0GiUuYWVncy5jbG92ZXIudjEuQ2FuY2VsQ29udGFjdFJlc3BvbnNlEnEKFExpc3RDb250YWN0QmxvYkZpbGVzEisuYWVncy5jbG92ZXIudjEuTGlzdENvbnRhY3RCbG9iRmlsZXNSZXF1ZXN0GiwuYWVncy5jbG92ZXIudjEuTGlzdENvbnRhY3RCbG9iRmlsZXNSZXNwb25zZWIGcHJvdG8z", [file_aegs_clover_v1_models, file_google_protobuf_timestamp]);
 
 /**
  * @generated from message aegs.clover.v1.ListSatellitesRequest
@@ -531,6 +531,68 @@ export const ListUpcomingContactsResponseSchema: GenMessage<ListUpcomingContacts
   messageDesc(file_aegs_clover_v1_clover_service, 15);
 
 /**
+ * @generated from message aegs.clover.v1.ListPastContactsRequest
+ */
+export type ListPastContactsRequest = Message<"aegs.clover.v1.ListPastContactsRequest"> & {
+  /**
+   * コンタクトのリストを取得する対象の衛星 ID
+   *
+   * @generated from field: int64 satellite_id = 1;
+   */
+  satelliteId: bigint;
+};
+
+/**
+ * @generated from message aegs.clover.v1.ListPastContactsRequest
+ */
+export type ListPastContactsRequestJson = {
+  /**
+   * コンタクトのリストを取得する対象の衛星 ID
+   *
+   * @generated from field: int64 satellite_id = 1;
+   */
+  satelliteId?: string;
+};
+
+/**
+ * Describes the message aegs.clover.v1.ListPastContactsRequest.
+ * Use `create(ListPastContactsRequestSchema)` to create a new message.
+ */
+export const ListPastContactsRequestSchema: GenMessage<ListPastContactsRequest, ListPastContactsRequestJson> = /*@__PURE__*/
+  messageDesc(file_aegs_clover_v1_clover_service, 16);
+
+/**
+ * @generated from message aegs.clover.v1.ListPastContactsResponse
+ */
+export type ListPastContactsResponse = Message<"aegs.clover.v1.ListPastContactsResponse"> & {
+  /**
+   * 指定された衛星を対象とした過去14日以内のコンタクトのリスト
+   *
+   * @generated from field: repeated aegs.clover.v1.Contact contacts = 1;
+   */
+  contacts: Contact[];
+};
+
+/**
+ * @generated from message aegs.clover.v1.ListPastContactsResponse
+ */
+export type ListPastContactsResponseJson = {
+  /**
+   * 指定された衛星を対象とした過去14日以内のコンタクトのリスト
+   *
+   * @generated from field: repeated aegs.clover.v1.Contact contacts = 1;
+   */
+  contacts?: ContactJson[];
+};
+
+/**
+ * Describes the message aegs.clover.v1.ListPastContactsResponse.
+ * Use `create(ListPastContactsResponseSchema)` to create a new message.
+ */
+export const ListPastContactsResponseSchema: GenMessage<ListPastContactsResponse, ListPastContactsResponseJson> = /*@__PURE__*/
+  messageDesc(file_aegs_clover_v1_clover_service, 17);
+
+/**
  * @generated from message aegs.clover.v1.GetContactRequest
  */
 export type GetContactRequest = Message<"aegs.clover.v1.GetContactRequest"> & {
@@ -559,7 +621,7 @@ export type GetContactRequestJson = {
  * Use `create(GetContactRequestSchema)` to create a new message.
  */
 export const GetContactRequestSchema: GenMessage<GetContactRequest, GetContactRequestJson> = /*@__PURE__*/
-  messageDesc(file_aegs_clover_v1_clover_service, 16);
+  messageDesc(file_aegs_clover_v1_clover_service, 18);
 
 /**
  * @generated from message aegs.clover.v1.GetContactResponse
@@ -590,7 +652,7 @@ export type GetContactResponseJson = {
  * Use `create(GetContactResponseSchema)` to create a new message.
  */
 export const GetContactResponseSchema: GenMessage<GetContactResponse, GetContactResponseJson> = /*@__PURE__*/
-  messageDesc(file_aegs_clover_v1_clover_service, 17);
+  messageDesc(file_aegs_clover_v1_clover_service, 19);
 
 /**
  * @generated from message aegs.clover.v1.CreateContactRequest
@@ -663,7 +725,7 @@ export type CreateContactRequestJson = {
  * Use `create(CreateContactRequestSchema)` to create a new message.
  */
 export const CreateContactRequestSchema: GenMessage<CreateContactRequest, CreateContactRequestJson> = /*@__PURE__*/
-  messageDesc(file_aegs_clover_v1_clover_service, 18);
+  messageDesc(file_aegs_clover_v1_clover_service, 20);
 
 /**
  * @generated from message aegs.clover.v1.CreateContactResponse
@@ -694,7 +756,7 @@ export type CreateContactResponseJson = {
  * Use `create(CreateContactResponseSchema)` to create a new message.
  */
 export const CreateContactResponseSchema: GenMessage<CreateContactResponse, CreateContactResponseJson> = /*@__PURE__*/
-  messageDesc(file_aegs_clover_v1_clover_service, 19);
+  messageDesc(file_aegs_clover_v1_clover_service, 21);
 
 /**
  * @generated from message aegs.clover.v1.CancelContactRequest
@@ -725,7 +787,7 @@ export type CancelContactRequestJson = {
  * Use `create(CancelContactRequestSchema)` to create a new message.
  */
 export const CancelContactRequestSchema: GenMessage<CancelContactRequest, CancelContactRequestJson> = /*@__PURE__*/
-  messageDesc(file_aegs_clover_v1_clover_service, 20);
+  messageDesc(file_aegs_clover_v1_clover_service, 22);
 
 /**
  * @generated from message aegs.clover.v1.CancelContactResponse
@@ -756,7 +818,69 @@ export type CancelContactResponseJson = {
  * Use `create(CancelContactResponseSchema)` to create a new message.
  */
 export const CancelContactResponseSchema: GenMessage<CancelContactResponse, CancelContactResponseJson> = /*@__PURE__*/
-  messageDesc(file_aegs_clover_v1_clover_service, 21);
+  messageDesc(file_aegs_clover_v1_clover_service, 23);
+
+/**
+ * @generated from message aegs.clover.v1.ListContactBlobFilesRequest
+ */
+export type ListContactBlobFilesRequest = Message<"aegs.clover.v1.ListContactBlobFilesRequest"> & {
+  /**
+   * ファイルのリストを取得するコンタクトの ID
+   *
+   * @generated from field: int64 contact_id = 1;
+   */
+  contactId: bigint;
+};
+
+/**
+ * @generated from message aegs.clover.v1.ListContactBlobFilesRequest
+ */
+export type ListContactBlobFilesRequestJson = {
+  /**
+   * ファイルのリストを取得するコンタクトの ID
+   *
+   * @generated from field: int64 contact_id = 1;
+   */
+  contactId?: string;
+};
+
+/**
+ * Describes the message aegs.clover.v1.ListContactBlobFilesRequest.
+ * Use `create(ListContactBlobFilesRequestSchema)` to create a new message.
+ */
+export const ListContactBlobFilesRequestSchema: GenMessage<ListContactBlobFilesRequest, ListContactBlobFilesRequestJson> = /*@__PURE__*/
+  messageDesc(file_aegs_clover_v1_clover_service, 24);
+
+/**
+ * @generated from message aegs.clover.v1.ListContactBlobFilesResponse
+ */
+export type ListContactBlobFilesResponse = Message<"aegs.clover.v1.ListContactBlobFilesResponse"> & {
+  /**
+   * コンタクトで生成されたファイルのリスト
+   *
+   * @generated from field: repeated aegs.clover.v1.BlobFile blob_files = 1;
+   */
+  blobFiles: BlobFile[];
+};
+
+/**
+ * @generated from message aegs.clover.v1.ListContactBlobFilesResponse
+ */
+export type ListContactBlobFilesResponseJson = {
+  /**
+   * コンタクトで生成されたファイルのリスト
+   *
+   * @generated from field: repeated aegs.clover.v1.BlobFile blob_files = 1;
+   */
+  blobFiles?: BlobFileJson[];
+};
+
+/**
+ * Describes the message aegs.clover.v1.ListContactBlobFilesResponse.
+ * Use `create(ListContactBlobFilesResponseSchema)` to create a new message.
+ */
+export const ListContactBlobFilesResponseSchema: GenMessage<ListContactBlobFilesResponse, ListContactBlobFilesResponseJson> = /*@__PURE__*/
+  messageDesc(file_aegs_clover_v1_clover_service, 25);
 
 /**
  * アークエッジ・スペースの地上局予約サービス。
@@ -846,6 +970,16 @@ export const CloverService: GenService<{
     output: typeof ListUpcomingContactsResponseSchema;
   },
   /**
+   * 指定した衛星について、end_time が過去14日以内のコンタクトのリストを取得する。
+   *
+   * @generated from rpc aegs.clover.v1.CloverService.ListPastContacts
+   */
+  listPastContacts: {
+    methodKind: "unary";
+    input: typeof ListPastContactsRequestSchema;
+    output: typeof ListPastContactsResponseSchema;
+  },
+  /**
    * 指定したコンタクトを取得する。
    *
    * @generated from rpc aegs.clover.v1.CloverService.GetContact
@@ -877,6 +1011,17 @@ export const CloverService: GenService<{
     methodKind: "unary";
     input: typeof CancelContactRequestSchema;
     output: typeof CancelContactResponseSchema;
+  },
+  /**
+   * 指定したコンタクトで得られたファイルのリストを取得する。
+   * コンタクトがファイルを生成するよう設定されていない場合は NOT_FOUND (5) のエラーが返る。
+   *
+   * @generated from rpc aegs.clover.v1.CloverService.ListContactBlobFiles
+   */
+  listContactBlobFiles: {
+    methodKind: "unary";
+    input: typeof ListContactBlobFilesRequestSchema;
+    output: typeof ListContactBlobFilesResponseSchema;
   },
 }> = /*@__PURE__*/
   serviceDesc(file_aegs_clover_v1_clover_service, 0);

--- a/client-ui/app/gen/aegs/clover/v1/models_pb.ts
+++ b/client-ui/app/gen/aegs/clover/v1/models_pb.ts
@@ -12,7 +12,7 @@ import type { Message } from "@bufbuild/protobuf";
  * Describes the file aegs/clover/v1/models.proto.
  */
 export const file_aegs_clover_v1_models: GenFile = /*@__PURE__*/
-  fileDesc("ChthZWdzL2Nsb3Zlci92MS9tb2RlbHMucHJvdG8SDmFlZ3MuY2xvdmVyLnYxIiUKCVNhdGVsbGl0ZRIKCgJpZBgBIAEoAxIMCgRuYW1lGAIgASgJImwKCVRMRVJlY29yZBIKCgJpZBgBIAEoAxIgCgN0bGUYAiABKAsyEy5hZWdzLmNsb3Zlci52MS5UTEUSMQoNcmVnaXN0ZXJfdGltZRgDIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXAiIwoDVExFEg0KBWxpbmUxGAEgASgJEg0KBWxpbmUyGAIgASgJIlYKDUdyb3VuZFN0YXRpb24SCgoCaWQYASABKAMSDAoEbmFtZRgCIAEoCRIrCghsb2NhdGlvbhgDIAEoCzIZLmFlZ3MuY2xvdmVyLnYxLkxhdExuZ0FsdCJCCglMYXRMbmdBbHQSEAoIbGF0aXR1ZGUYASABKAESEQoJbG9uZ2l0dWRlGAIgASgBEhAKCGFsdGl0dWRlGAMgASgBIq8BCgRQYXNzEiwKCXNhdGVsbGl0ZRgBIAEoCzIZLmFlZ3MuY2xvdmVyLnYxLlNhdGVsbGl0ZRI1Cg5ncm91bmRfc3RhdGlvbhgCIAEoCzIdLmFlZ3MuY2xvdmVyLnYxLkdyb3VuZFN0YXRpb24SLAoHZGV0YWlscxgDIAEoCzIbLmFlZ3MuY2xvdmVyLnYxLlBhc3NEZXRhaWxzEhQKDGlzX2F2YWlsYWJsZRgEIAEoCCJ2CgtQYXNzRGV0YWlscxInCgNhb3MYASABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wEicKA2xvcxgCIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASFQoNbWF4X2VsZXZhdGlvbhgDIAEoASKVBAoHQ29udGFjdBIKCgJpZBgBIAEoAxIUCgxzYXRlbGxpdGVfaWQYAiABKAMSGQoRZ3JvdW5kX3N0YXRpb25faWQYAyABKAMSLgoGc3RhdHVzGAQgASgOMh4uYWVncy5jbG92ZXIudjEuQ29udGFjdC5TdGF0dXMSLgoKc3RhcnRfdGltZRgFIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASLAoIZW5kX3RpbWUYBiABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wEi8KC2NyZWF0ZV90aW1lGAcgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcBIvCgt1cGRhdGVfdGltZRgIIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASKQoEcGFzcxgJIAEoCzIbLmFlZ3MuY2xvdmVyLnYxLlBhc3NEZXRhaWxzIrEBCgZTdGF0dXMSFgoSU1RBVFVTX1VOU1BFQ0lGSUVEEAASEgoOU1RBVFVTX1BFTkRJTkcQARIUChBTVEFUVVNfU0NIRURVTEVEEAISEwoPU1RBVFVTX1JFSkVDVEVEEAMSEwoPU1RBVFVTX0NBTkNFTEVEEAQSEgoOU1RBVFVTX1JVTk5JTkcQBRIUChBTVEFUVVNfQ09NUExFVEVEEAYSEQoNU1RBVFVTX0ZBSUxFRBAHYgZwcm90bzM", [file_google_protobuf_timestamp]);
+  fileDesc("ChthZWdzL2Nsb3Zlci92MS9tb2RlbHMucHJvdG8SDmFlZ3MuY2xvdmVyLnYxIiUKCVNhdGVsbGl0ZRIKCgJpZBgBIAEoAxIMCgRuYW1lGAIgASgJImwKCVRMRVJlY29yZBIKCgJpZBgBIAEoAxIgCgN0bGUYAiABKAsyEy5hZWdzLmNsb3Zlci52MS5UTEUSMQoNcmVnaXN0ZXJfdGltZRgDIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXAiIwoDVExFEg0KBWxpbmUxGAEgASgJEg0KBWxpbmUyGAIgASgJIlYKDUdyb3VuZFN0YXRpb24SCgoCaWQYASABKAMSDAoEbmFtZRgCIAEoCRIrCghsb2NhdGlvbhgDIAEoCzIZLmFlZ3MuY2xvdmVyLnYxLkxhdExuZ0FsdCJCCglMYXRMbmdBbHQSEAoIbGF0aXR1ZGUYASABKAESEQoJbG9uZ2l0dWRlGAIgASgBEhAKCGFsdGl0dWRlGAMgASgBIq8BCgRQYXNzEiwKCXNhdGVsbGl0ZRgBIAEoCzIZLmFlZ3MuY2xvdmVyLnYxLlNhdGVsbGl0ZRI1Cg5ncm91bmRfc3RhdGlvbhgCIAEoCzIdLmFlZ3MuY2xvdmVyLnYxLkdyb3VuZFN0YXRpb24SLAoHZGV0YWlscxgDIAEoCzIbLmFlZ3MuY2xvdmVyLnYxLlBhc3NEZXRhaWxzEhQKDGlzX2F2YWlsYWJsZRgEIAEoCCJ2CgtQYXNzRGV0YWlscxInCgNhb3MYASABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wEicKA2xvcxgCIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASFQoNbWF4X2VsZXZhdGlvbhgDIAEoASKVBAoHQ29udGFjdBIKCgJpZBgBIAEoAxIUCgxzYXRlbGxpdGVfaWQYAiABKAMSGQoRZ3JvdW5kX3N0YXRpb25faWQYAyABKAMSLgoGc3RhdHVzGAQgASgOMh4uYWVncy5jbG92ZXIudjEuQ29udGFjdC5TdGF0dXMSLgoKc3RhcnRfdGltZRgFIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASLAoIZW5kX3RpbWUYBiABKAsyGi5nb29nbGUucHJvdG9idWYuVGltZXN0YW1wEi8KC2NyZWF0ZV90aW1lGAcgASgLMhouZ29vZ2xlLnByb3RvYnVmLlRpbWVzdGFtcBIvCgt1cGRhdGVfdGltZRgIIAEoCzIaLmdvb2dsZS5wcm90b2J1Zi5UaW1lc3RhbXASKQoEcGFzcxgJIAEoCzIbLmFlZ3MuY2xvdmVyLnYxLlBhc3NEZXRhaWxzIrEBCgZTdGF0dXMSFgoSU1RBVFVTX1VOU1BFQ0lGSUVEEAASEgoOU1RBVFVTX1BFTkRJTkcQARIUChBTVEFUVVNfU0NIRURVTEVEEAISEwoPU1RBVFVTX1JFSkVDVEVEEAMSEwoPU1RBVFVTX0NBTkNFTEVEEAQSEgoOU1RBVFVTX1JVTk5JTkcQBRIUChBTVEFUVVNfQ09NUExFVEVEEAYSEQoNU1RBVFVTX0ZBSUxFRBAHIjcKCEJsb2JGaWxlEgsKA3VybBgBIAEoCRIQCghmaWxlbmFtZRgCIAEoCRIMCgRzaXplGAMgASgDYgZwcm90bzM", [file_google_protobuf_timestamp]);
 
 /**
  * 衛星。
@@ -685,4 +685,67 @@ export type Contact_StatusJson = "STATUS_UNSPECIFIED" | "STATUS_PENDING" | "STAT
  */
 export const Contact_StatusSchema: GenEnum<Contact_Status, Contact_StatusJson> = /*@__PURE__*/
   enumDesc(file_aegs_clover_v1_models, 7, 0);
+
+/**
+ * URL からダウンロード可能なファイル。
+ *
+ * @generated from message aegs.clover.v1.BlobFile
+ */
+export type BlobFile = Message<"aegs.clover.v1.BlobFile"> & {
+  /**
+   * ファイルをダウンロードするための URL
+   *
+   * @generated from field: string url = 1;
+   */
+  url: string;
+
+  /**
+   * ファイル名
+   *
+   * @generated from field: string filename = 2;
+   */
+  filename: string;
+
+  /**
+   * ファイルのサイズ [byte]
+   *
+   * @generated from field: int64 size = 3;
+   */
+  size: bigint;
+};
+
+/**
+ * URL からダウンロード可能なファイル。
+ *
+ * @generated from message aegs.clover.v1.BlobFile
+ */
+export type BlobFileJson = {
+  /**
+   * ファイルをダウンロードするための URL
+   *
+   * @generated from field: string url = 1;
+   */
+  url?: string;
+
+  /**
+   * ファイル名
+   *
+   * @generated from field: string filename = 2;
+   */
+  filename?: string;
+
+  /**
+   * ファイルのサイズ [byte]
+   *
+   * @generated from field: int64 size = 3;
+   */
+  size?: string;
+};
+
+/**
+ * Describes the message aegs.clover.v1.BlobFile.
+ * Use `create(BlobFileSchema)` to create a new message.
+ */
+export const BlobFileSchema: GenMessage<BlobFile, BlobFileJson> = /*@__PURE__*/
+  messageDesc(file_aegs_clover_v1_models, 8);
 

--- a/client-ui/app/root.tsx
+++ b/client-ui/app/root.tsx
@@ -1,6 +1,4 @@
 import { Alignment, Button, Navbar } from "@blueprintjs/core";
-import "@blueprintjs/core/lib/css/blueprint.css";
-import "@blueprintjs/icons/lib/css/blueprint-icons.css";
 import { LinksFunction, MetaFunction } from "@remix-run/node";
 import {
   Links,
@@ -12,6 +10,10 @@ import {
 } from "@remix-run/react";
 import logo from "./assets/logo.svg";
 import "./tailwind.css";
+
+// These must be after the tailwind.css import
+import "@blueprintjs/core/lib/css/blueprint.css";
+import "@blueprintjs/icons/lib/css/blueprint-icons.css";
 
 export const meta: MetaFunction = () => [
   { title: "Clover UI - ArkEdge Space" },

--- a/client-ui/app/routes/satellites.$satelliteId._index.tsx
+++ b/client-ui/app/routes/satellites.$satelliteId._index.tsx
@@ -164,10 +164,18 @@ function TLESection() {
 }
 
 function ContactsSection() {
-  const { groundStations, contacts } = useLoaderData<typeof loader>();
+  const { satellite, groundStations, contacts } =
+    useLoaderData<typeof loader>();
 
   return (
-    <Section title="Upcoming Contacts">
+    <Section
+      title="Upcoming Contacts"
+      rightElement={
+        <Link to={`/satellites/${satellite.id}/contacts`}>
+          <Button minimal={true} intent={Intent.PRIMARY} text="Past Contacts" />
+        </Link>
+      }
+    >
       {contacts.length ? (
         <ContactTable contacts={contacts} groundStations={groundStations} />
       ) : (

--- a/client-ui/app/routes/satellites.$satelliteId._index.tsx
+++ b/client-ui/app/routes/satellites.$satelliteId._index.tsx
@@ -29,7 +29,7 @@ import {
 import { useState } from "react";
 import invariant from "tiny-invariant";
 import { CloverClient } from "~/.server/CloverClient";
-import { ContactStatusTag } from "~/components/ContactStatusTag";
+import { ContactTable } from "~/components/ContactTable";
 import { PassJson } from "~/gen/aegs/clover/v1/models_pb";
 
 export const loader = async ({ params }: LoaderFunctionArgs) => {
@@ -169,42 +169,7 @@ function ContactsSection() {
   return (
     <Section title="Upcoming Contacts">
       {contacts.length ? (
-        <HTMLTable striped={true} interactive={true} className="w-full">
-          <thead>
-            <tr>
-              <th>ID</th>
-              <th>Ground Station</th>
-              <th>Start Time</th>
-              <th>End Time</th>
-              <th>Status</th>
-            </tr>
-          </thead>
-          <tbody>
-            {contacts.map((contact) => (
-              <tr key={contact.id} className="relative">
-                <td>
-                  <Link
-                    to={`/contacts/${contact.id}`}
-                    className="absolute inset-0"
-                  />
-                  {contact.id}
-                </td>
-                <td>
-                  {
-                    groundStations.find(
-                      (gs) => gs.id === contact.groundStationId,
-                    )?.name
-                  }
-                </td>
-                <td>{contact.startTime}</td>
-                <td>{contact.endTime}</td>
-                <td>
-                  <ContactStatusTag status={contact.status!} />
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </HTMLTable>
+        <ContactTable contacts={contacts} groundStations={groundStations} />
       ) : (
         <NonIdealState
           layout="horizontal"

--- a/client-ui/app/routes/satellites.$satelliteId.contacts.tsx
+++ b/client-ui/app/routes/satellites.$satelliteId.contacts.tsx
@@ -1,0 +1,55 @@
+import { Breadcrumbs, Section } from "@blueprintjs/core";
+import { json, LoaderFunctionArgs, MetaFunction } from "@remix-run/node";
+import { useLoaderData } from "@remix-run/react";
+import invariant from "tiny-invariant";
+import { CloverClient } from "~/.server/CloverClient";
+import { ContactTable } from "~/components/ContactTable";
+
+export const loader = async ({ params }: LoaderFunctionArgs) => {
+  invariant(params.satelliteId, "Missing satelliteId param");
+  let satelliteId: bigint;
+  try {
+    satelliteId = BigInt(params.satelliteId);
+  } catch {
+    throw new Response(null, { status: 404, statusText: "Not Found" });
+  }
+
+  const client = new CloverClient();
+  const satellite = await client.getSatellite(satelliteId);
+  if (!satellite) {
+    throw new Response(null, { status: 404, statusText: "Not Found" });
+  }
+  const groundStations = await client.listAvailableGroundStations(satelliteId);
+  const contacts = await client.listPastContacts(satelliteId);
+
+  return json({ satellite, groundStations, contacts });
+};
+
+export const meta: MetaFunction<typeof loader> = ({ data }) => [
+  { title: `${data?.satellite.name} Past Contacts` },
+];
+
+export default function SatelliteTLEPage() {
+  const { satellite, groundStations, contacts } =
+    useLoaderData<typeof loader>();
+
+  return (
+    <main className="container mx-auto space-y-6 py-8">
+      <Breadcrumbs
+        items={[
+          { href: "/", icon: "home", text: "Home" },
+          {
+            href: `/satellites/${satellite.id}`,
+            icon: "satellite",
+            text: satellite.name,
+          },
+          { text: "Past Contacts" },
+        ]}
+      />
+
+      <Section title="Past Contacts">
+        <ContactTable contacts={contacts} groundStations={groundStations} />
+      </Section>
+    </main>
+  );
+}

--- a/client-ui/app/routes/satellites.$satelliteId.tle.tsx
+++ b/client-ui/app/routes/satellites.$satelliteId.tle.tsx
@@ -88,7 +88,11 @@ export default function SatelliteTLEPage() {
       <Breadcrumbs
         items={[
           { href: "/", icon: "home", text: "Home" },
-          { icon: "satellite", text: satellite.name },
+          {
+            href: `/satellites/${satellite.id}`,
+            icon: "satellite",
+            text: satellite.name,
+          },
           { text: "TLE" },
         ]}
       />


### PR DESCRIPTION
Clover API クライアントの参考実装 Clover UI で過去のコンタクトを一覧できるようにし、`ListContactBlobFiles` で取得した URL をコンタクト詳細ページで一覧できるようにします。