### PR TITLE
change renovate option to disable automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -37,7 +37,7 @@
         "minor",
         "patch"
       ],
-      "automerge": true
+      "automerge": false
     }
   ],
   "labels": [


### PR DESCRIPTION
# 概要

npmのサプライチェーンアタックに対応して全てのnpmに依存しているrepositoryのautomergeを停止します