### PR TITLE
Add generation and bundling of third-party licenses

### DIFF
--- a/client-ui/.gitignore
+++ b/client-ui/.gitignore
@@ -4,3 +4,4 @@ node_modules
 /.react-router
 /build
 .env
+/THIRD_PARTY_LICENSES.txt

--- a/client-ui/Dockerfile
+++ b/client-ui/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:24-bullseye-slim AS base
 
 ENV NODE_ENV=production
+ENV CI=true
 
 # https://github.com/nodejs/corepack/issues/612#issuecomment-2629496091
 RUN npm install -g corepack@latest
@@ -18,6 +19,7 @@ RUN pnpm install --frozen-lockfile --prod=false
 
 COPY . .
 RUN pnpm run build
+RUN pnpm run gen:licenses
 RUN pnpm prune --prod
 
 # runtime stage
@@ -30,6 +32,7 @@ COPY package.json .
 COPY --from=build /app/node_modules /app/node_modules
 COPY --from=build /app/build/client /app/build/client
 COPY --from=build /app/build/server /app/build/server
+COPY --from=build /app/THIRD_PARTY_LICENSES.txt /app/THIRD_PARTY_LICENSES.txt
 
 RUN corepack install
 

--- a/client-ui/eslint.config.js
+++ b/client-ui/eslint.config.js
@@ -15,7 +15,7 @@ export default defineConfig([
       globals: { ...globals.browser, ...globals.node },
     },
   },
-  globalIgnores(["build/", ".react-router/"]),
+  globalIgnores(["build/", ".react-router/", "scripts/"]),
   eslint.configs.recommended,
 
   // TypeScript

--- a/client-ui/package.json
+++ b/client-ui/package.json
@@ -10,7 +10,8 @@
     "lint": "prettier --check . && eslint",
     "start": "react-router-serve ./build/server/index.js",
     "typecheck": "tsc",
-    "gen:proto": "buf generate"
+    "gen:proto": "buf generate",
+    "gen:licenses": "node scripts/gen-third-party-licenses.mjs"
   },
   "dependencies": {
     "@blueprintjs/core": "^6.0.0",

--- a/client-ui/scripts/gen-third-party-licenses.mjs
+++ b/client-ui/scripts/gen-third-party-licenses.mjs
@@ -1,0 +1,62 @@
+#!/usr/bin/env node
+// Generates THIRD_PARTY_LICENSES.txt covering every production dependency
+// bundled into the distributed container image, as required for binary
+// redistribution under most OSS licenses (MIT/BSD/Apache-2.0 etc.).
+import { execFileSync } from "node:child_process";
+import { readdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+const LICENSE_FILE_RE = /^(license|licence|copying)(\.(md|txt))?$/i;
+
+function findLicenseText(dir) {
+  let files;
+  try {
+    files = readdirSync(dir);
+  } catch {
+    return null;
+  }
+  const licenseFile = files.find((f) => LICENSE_FILE_RE.test(f));
+  if (!licenseFile) return null;
+  return readFileSync(join(dir, licenseFile), "utf8").trim();
+}
+
+const raw = execFileSync("pnpm", ["licenses", "list", "--json", "--prod"], {
+  maxBuffer: 1024 * 1024 * 32,
+}).toString();
+const byLicense = JSON.parse(raw);
+
+const packages = [];
+for (const [license, pkgs] of Object.entries(byLicense)) {
+  for (const pkg of pkgs) {
+    packages.push({ ...pkg, license });
+  }
+}
+packages.sort((a, b) => a.name.localeCompare(b.name));
+
+const sections = packages.map((pkg) => {
+  const header = [
+    `${pkg.name}@${pkg.versions.join(", ")}`,
+    `License: ${pkg.license}`,
+    pkg.homepage ? `Homepage: ${pkg.homepage}` : null,
+  ]
+    .filter(Boolean)
+    .join("\n");
+
+  const text = findLicenseText(pkg.paths[0]);
+  const body =
+    text ?? "(license text not found in package; see homepage above)";
+
+  return `${header}\n\n${body}`;
+});
+
+const banner =
+  "This file lists the third-party open source dependencies bundled into\n" +
+  "the clover-ui container image, along with their license texts, as\n" +
+  "required for redistribution.\n";
+
+const out = `${banner}\n${"=".repeat(80)}\n\n${sections.join(`\n\n${"=".repeat(80)}\n\n`)}\n`;
+
+writeFileSync("THIRD_PARTY_LICENSES.txt", out);
+console.log(
+  `Wrote THIRD_PARTY_LICENSES.txt covering ${packages.length} packages.`,
+);


### PR DESCRIPTION
サード・パーティ・ライセンスファイルの生成と梱包を追加します。

clover-ui は GHCR 経由でコンテナイメージ(バイナリ)として配布されるため、
バンドルされている依存パッケージのライセンス表示が必要でした。
ビルド時に依存パッケージのライセンスを収集し、THIRD_PARTY_LICENSES.txt
としてイメージに含めるようにしました。