### PR TITLE
fix: pnpm の minimumReleaseAge を有効にする

### DIFF
--- a/client-ui/pnpm-workspace.yaml
+++ b/client-ui/pnpm-workspace.yaml
@@ -1,0 +1,7 @@
+packages:
+  - .
+
+# 公開直後のバージョンを install しない（サプライチェーン攻撃対策）
+# 実効性は `pnpm config get minimumReleaseAge` で確認できる（undefined なら効いていない）
+# 詰まった場合は `pnpm add <pkg> --config.minimumReleaseAge=0` で一時的に回避する
+minimumReleaseAge: 10080 # 7 days in minutes


### PR DESCRIPTION
`client-ui` に pnpm の [`minimumReleaseAge`](https://pnpm.io/settings/dependency-resolution#minimumreleaseage) を 7 日（10080 分）で設定します。公開直後のバージョンを install しないことで、汚染された版が公開されてから削除されるまでの窓を避けられます。

検証（pnpm 10.32.1）: `pnpm config get minimumReleaseAge` → `10080` / `pnpm install --lockfile-only --ignore-scripts` で `pnpm-lock.yaml` に差分なし。

公開直後の版を入れたいときは `pnpm add <pkg> --config.minimumReleaseAge=0`、恒久的な例外は `minimumReleaseAgeExclude` を使ってください。
